### PR TITLE
Fix json tag for SubmittedAt and CompletedAt fields

### DIFF
--- a/go/sample.go
+++ b/go/sample.go
@@ -62,8 +62,8 @@ type Sample struct {
 	Filename    string       `json:"filename"`
 	URL         string       `json:"url"`
 	Tasks       []Task       `json:"tasks"`
-	SubmittedAt time.Time    `json:"completed"`
-	CompletedAt *time.Time   `json:"submitted"`
+	SubmittedAt time.Time    `json:"submitted"`
+	CompletedAt *time.Time   `json:"completed"`
 }
 
 type ProfileSelection struct {


### PR DESCRIPTION
As per https://tria.ge/docs/cloud-api/samples/#the-sample-object
"submitted" should map to the time the sample was submitted, whereas
"completed" should map to the time the sample was completed.