### PR TITLE
add documentation for `network` argument of client.py:create_profile

### DIFF
--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -446,6 +446,7 @@ class Client:
         Parameters:
             name (str): The name of the profile
             tags (list): Tags for the profile, list of strings
+            network (list): network used when running the sample (Currently available : "", "drop", "internet")
             timeout (int): The timeout of the profile
 
         Returns:


### PR DESCRIPTION
list of values taken from https://tria.ge/docs/cloud-api/profiles/