### PR TITLE
Fixes to go and python clients

### DIFF
--- a/go/report.go
+++ b/go/report.go
@@ -60,7 +60,7 @@ func (c *Client) SampleTaskKernelReport(ctx context.Context, sampleID, taskID st
 	switch {
 	case strings.Contains(task.Platform, "windows"):
 		proto = "onemon.json"
-	case strings.Contains(task.Platform, "linux"):
+	case strings.Contains(task.Platform, "linux"), strings.Contains(task.Platform, "ubuntu"):
 		proto = "stahp.json"
 	case strings.Contains(task.Platform, "macos"):
 		proto = "bigmac.json"

--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -351,18 +351,21 @@ class Client:
         else:
             raise ValueError("Task does not exist")
 
+        log_file = None
         if "windows" in task["platform"]:
-            r =  self._new_request(
-                'GET', '/v0/samples/{0}/{1}/logs/onemon.json'.format(
-                    sample_id, task_id)
-            )
-        elif "linux" in task["platform"]:
-            r =  self._new_request(
-                'GET', '/v0/samples/{0}/{1}/logs/stahp.json'.format(
-                    sample_id, task_id)
-            )
+            log_file = "onemon"
+        elif "linux" in task["platform"] or "ubuntu" in task["platform"]:
+            log_file = "stahp"
+        elif "macos" in task["platform"]:
+            log_file = "bigmac"
+        elif "android" in task["platform"]:
+            log_file = "droidy"
         else:
             raise ValueError("Platform not supported")
+
+        r =  self._new_request(
+                'GET', '/v0/samples/{0}/{1}/logs/{2}.json'.format(
+                    sample_id, task_id, log_file)
 
         with Session() as s:
             settings = s.merge_environment_settings(r.url, {}, None, False, None)


### PR DESCRIPTION
Hello Team,

For a given linux sample (ex: **sample_id: "220321-15re6altvr"**), 

in kernel_report function - https://github.com/hatching/triage/blob/main/python/triage/client.py#L359 there's a minor discrepancy in overview_report -> tasks -> **platform** value.

task["platform'] may contain 'ubuntu' instead of 'linux' (in this example: 'ubuntu_amd64'). Although the stahp.json log file is available, instead of fetching it successfully, it's throwing a "Platform not supported" error. This error is thrown in both **go and python** clients. 

A couple of fixes here:

1. For both go, and python clients - added another case to search for 'ubuntu' in task.Platform and task["platform"]
2. For python client, added support for 'macos' and 'android' log files as well.

Thank you very much. Please let me know if you have any questions or comments.