### PR TITLE
Replaces use of default mutable arguments in a function

### DIFF
--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -20,7 +20,9 @@ class Client:
         self.token = token
         self.root_url = root_url.rstrip('/')
 
-    def _new_request(self, method, path, j=None, b=None, headers={}):
+    def _new_request(self, method, path, j=None, b=None, headers=None):
+        if headers is None:
+            headers = {}
         headers = {
             'Authorization': 'Bearer {0}'.format(self.token),
             'User-Agent': 'Triage Python Client/{0} Python/{1}'
@@ -53,8 +55,7 @@ class Client:
         except exceptions.HTTPError as err:
             raise ServerError(err)
 
-    def submit_sample_file(self, filename, file, interactive=False,
-                           profiles=[], password=None):
+    def submit_sample_file(self, filename, file, interactive=False, profiles=None, password=None):
         """
         Submit a file for analysis on Triage.
 
@@ -86,6 +87,8 @@ class Client:
                     'submitted': '2020-09-23T07:26:26Z'
                 }
         """
+        if profiles is None:
+            profiles = []
         d = {
             'kind': 'file',
             'interactive': interactive,
@@ -109,7 +112,7 @@ class Client:
         except exceptions.HTTPError as err:
             raise ServerError(err)
 
-    def submit_sample_url(self, url, interactive=False, profiles=[]):
+    def submit_sample_url(self, url, interactive=False, profiles=None):
         """
         Submit a url for analysis on Triage.
 
@@ -135,6 +138,8 @@ class Client:
                     'submitted': '2020-09-23T07:51:45Z'
                 }
         """
+        if profiles is None:
+            profiles = []
         return self._req_json('POST', '/v0/samples', {
             'kind': 'url',
             'url': url,
@@ -166,7 +171,7 @@ class Client:
             'profiles': profiles,
         })
 
-    def set_sample_profile_automatically(self, sample_id, pick=[]):
+    def set_sample_profile_automatically(self, sample_id, pick=None):
         """
         Set profile for a sample automatically, if the sample has been
         submitted in interactive mode.
@@ -183,6 +188,8 @@ class Client:
             response (dict):
                 {}, empty dict
         """
+        if pick is None:
+            pick = []
         return self._req_json('POST', '/v0/samples/%s/profile' % sample_id, {
             'auto': True,
             'pick': pick,


### PR DESCRIPTION
Hi all,

I would like to start to get familiar with the Triage codebase by trying to help deal with some problems 😄 .

In this pull request, I found that there is some usage of [default mutable arguments](https://docs.python-guide.org/writing/gotchas/) in a function, which will lead to problems like the below code:

```python
def func(key, value, a={}):
    a[key] = value
    return a

>>> print(func('a', 10))  # that's expected
{'a': 10}
>>> print(func('b', 20))  # that could be unexpected
{'b': 20, 'a': 10}
```

To deal with that, we can put `None` in arguments and then check this argument within the function.

Reference:
[1] https://docs.sourcery.ai/suggestions/default-mutable-arg/
[2] https://docs.python-guide.org/writing/gotchas/
[3] https://stackoverflow.com/questions/41686829/warning-about-mutable-default-argument-in-pycharm