### PR TITLE
prevent key errors while select-profile with sample not found

### DIFF
--- a/python/cli/triage.py
+++ b/python/cli/triage.py
@@ -90,8 +90,12 @@ def prompt_select_profiles_for_files(profiles, pick):
     return rt
 
 def prompt_select_profile(c, sample):
+
     for events in c.sample_events(sample):
-        if events["status"] == "pending":
+        if "status" not in events and events["error"] == "NOT_FOUND":
+            print("sample not found")
+            return
+        elif events["status"] == "pending":
             print("waiting for static analysis to finish")
         elif events["status"] == "static_analysis":
             break


### PR DESCRIPTION
Hi all,

I just found that when I test `triage select-profile SAMPLE`

```bash=
triage  select-profile 220213-wn1kaabec8
```

It would be no problem with the existing code, but if I put another sample name that does not exist in Triage, it will crush the program as below:


```bash=
triage  select-profile 220213-wn1kaabec1
```

```
Traceback (most recent call last):
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/bin/triage", line 8, in <module>
    sys.exit(cli())
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/cli/triage.py", line 194, in select_profile
    prompt_select_profile(c, sample)
  File "/Users/nick/.local/share/virtualenvs/hatching-5YTFb6ti/lib/python3.8/site-packages/cli/triage.py", line 94, in prompt_select_profile
    if events["status"] == "pending":
KeyError: 'status'
```

After dumping the return of the function `sample_events`, I realize that there is no `status` key when the sample not found.


* Sample found


`{'id': '220213-wn1kaabec8', 'status': 'reported', 'kind': 'file', 'filename': 'DHLlApp.apk', 'private': False, 'tasks': [{'id': 'static1', 'status': 'reported'}, {'id': 'behavioral1', 'status': 'reported', 'target': 'DHLlApp.apk'}, {'id': 'behavioral2', 'status': 'reported', 'target': 'DHLlApp.apk'}, {'id': 'behavioral3', 'status': 'reported', 'target': 'DHLlApp.apk'}], 'submitted': '2022-02-13T18:04:48Z', 'completed': '2022-02-13T18:08:31Z'}`


* Sample not found

`{'error': 'NOT_FOUND', 'message': 'sample not found'}`




After fixed:

<img width="668" alt="截圖 2022-05-17 下午7 03 52" src="https://user-images.githubusercontent.com/16042160/168796918-141988a3-951a-4605-900c-7fc93dbb846c.png">