### PR TITLE
Starting in Go 1.17, installing executables with go get is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ well as Python. For a Java library, please see
 ### Installing the Go client
 
 ```bash
-$ go get github.com/hatching/triage/go/cmd/triage
+$ go install github.com/hatching/triage/go/cmd/triage@latest
 ```
 
 ### Installing the Python client


### PR DESCRIPTION
Hi there, just found that Install triage command-line using `go get` will not work starting from 1.17, it deprecated starting from Go.17.

```
go get github.com/hatching/triage/go/cmd/triage
```
will show error as below
<img width="948" alt="截圖 2022-07-29 下午7 35 17" src="https://user-images.githubusercontent.com/16042160/181752277-94e3ad21-8681-4d7a-b8a2-54bd56fd319f.png">

Go version: go version go1.18.4 darwin/arm64

Reference

https://go.dev/doc/go-get-install-deprecation