### PR TITLE
Fix for python client: kernel_report function

### DIFF
--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -352,13 +352,16 @@ class Client:
             raise ValueError("Task does not exist")
 
         log_file = None
-        if "windows" in task["platform"]:
+        task_platform = task.get("platform", "")
+        if not task_platform:
+            task_platform = task.get("os", "")
+        if "windows" in task_platform:
             log_file = "onemon"
-        elif "linux" in task["platform"] or "ubuntu" in task["platform"]:
+        elif "linux" in task_platform or "ubuntu" in task_platform:
             log_file = "stahp"
-        elif "macos" in task["platform"]:
+        elif "macos" in task_platform:
             log_file = "bigmac"
-        elif "android" in task["platform"]:
+        elif "android" in task_platform:
             log_file = "droidy"
         else:
             raise ValueError("Platform not supported")


### PR DESCRIPTION
Hello Team,

For a given sample (ex: sample_id: "220803-gbjcxaqytd"),

in kernel_report function - https://github.com/hatching/triage/blob/main/python/triage/client.py#L362 - lately 'platform' is not present in any of the triage tasks, for ex:

{'sample': '220803-gbjcxaqytd', 'kind': 'behavioral', 'name': 'behavioral1', 'status': 'reported', 'tags': ['family:icedid', 'campaign:3486167566', 'banker', 'loader', 'trojan'], 'score': 10, 'target': 'WbBf8RnN.dll', 'backend': 'sbx4m4', 'resource': 'win10v2004-20220414-en', 'task_name': 'horzn_win10_internet_120', **'os': 'windows10-2004-x64',** 'timeout': 120, 'sigs': 3}

Hence, It's constantly throwing the **KeyError: 'platform'** for every sample analysis. In such cases, we can use 'os' instead of solely relying on 'platform' field.

This error is thrown for all the samples that run on various platforms.

Thank you very much. Please let me know if you have any questions or comments.