### PR TITLE
Add timeout and network options for submissions

### DIFF
--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -55,7 +55,7 @@ class Client:
         except exceptions.HTTPError as err:
             raise ServerError(err)
 
-    def submit_sample_file(self, filename, file, interactive=False, profiles=None, password=None, timeout=60, network="internet"):
+    def submit_sample_file(self, filename, file, interactive=False, profiles=None, password=None, timeout=150, network="internet"):
         """
         Submit a file for analysis on Triage.
 

--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -55,7 +55,7 @@ class Client:
         except exceptions.HTTPError as err:
             raise ServerError(err)
 
-    def submit_sample_file(self, filename, file, interactive=False, profiles=None, password=None):
+    def submit_sample_file(self, filename, file, interactive=False, profiles=None, password=None, timeout=60, network="internet"):
         """
         Submit a file for analysis on Triage.
 
@@ -76,6 +76,10 @@ class Client:
                 ]
             password (str):
                 Password for the archive sample
+            timeout: (int):
+                Timeout of the analysis
+            network (str):
+                Type of network routing to use ("internet" | "drop" | "tor")
         Returns:
             response (dict):
                 {
@@ -93,6 +97,10 @@ class Client:
             'kind': 'file',
             'interactive': interactive,
             'profiles': profiles,
+            'defaults': {
+                'timeout': timeout,
+                'network': network
+            }
         }
         if password:
             d['password'] = password

--- a/python/triage/client.py
+++ b/python/triage/client.py
@@ -79,7 +79,7 @@ class Client:
             timeout: (int):
                 Timeout of the analysis
             network (str):
-                Type of network routing to use ("internet" | "drop" | "tor")
+                Type of network routing to use ("internet" | "drop" | "tor" | "sim200" | "sim404" | "simnx")
         Returns:
             response (dict):
                 {


### PR DESCRIPTION
Adds the ability to specify timeout and network options to the Python client's `submit_sample_file` method.