### PR TITLE
porting Python client's submit_sample_file based on #27 to Golang 

### DIFF
--- a/go/cmd/triage/main.go
+++ b/go/cmd/triage/main.go
@@ -335,7 +335,7 @@ func (c *Cli) submitSampleFile(arg0, target string, interactive bool, profiles [
 		}
 		defer fd.Close()
 		name := filepath.Base(sampleFile)
-		sample, submitErr = c.client.SubmitSampleFile(context.Background(), name, fd, interactive, profileSelections, nil)
+		sample, submitErr = c.client.SubmitSampleFile(context.Background(), name, fd, interactive, profileSelections, nil, nil, nil)
 
 	} else if sampleURL != "" {
 		sample, submitErr = c.client.SubmitSampleURL(context.Background(), sampleURL, interactive, profileSelections)

--- a/go/example/submit_sample_private.go
+++ b/go/example/submit_sample_private.go
@@ -18,6 +18,8 @@ const (
 
 var password = "password"
 var fname = "some-sample-path"
+var timeout = 150
+var network = "internet"
 
 func main() {
 	client := triage.NewPrivateClient(Token)
@@ -32,6 +34,8 @@ func main() {
 		false,
 		nil,
 		&password,
+		&timeout,
+		&network,
 	)
 	if err != nil {
 		panic(err)

--- a/go/example/submit_sample_public.go
+++ b/go/example/submit_sample_public.go
@@ -18,6 +18,8 @@ const (
 
 var password = "password"
 var fname = "some-sample-path"
+var timeout = 150
+var network = "internet"
 
 func main() {
 	client := triage.NewClient(Token)
@@ -32,6 +34,8 @@ func main() {
 		false,
 		nil,
 		&password,
+		&timeout,
+		&network,
 	)
 	if err != nil {
 		panic(err)

--- a/go/sample.go
+++ b/go/sample.go
@@ -71,26 +71,45 @@ type ProfileSelection struct {
 	Pick    string `json:"pick"`
 }
 
+type Defaults struct {
+	Timeout int    `json:"timeout"`
+	Network string `json:"network"`
+}
+
 type SampleEvent struct {
 	Sample
 	Error error
 }
 
-func (c *Client) SubmitSampleFile(ctx context.Context, filename string, file io.Reader, interactive bool, profiles []ProfileSelection, password *string) (*Sample, error) {
+func (c *Client) SubmitSampleFile(ctx context.Context, filename string, file io.Reader, interactive bool, profiles []ProfileSelection, password *string, timeout *int, network *string) (*Sample, error) {
 	var pw string
+	net := "internet"
+	tmo := 150
 	if password != nil && *password != "" {
 		pw = *password
 	}
+	if network != nil && *network != "" {
+		net = *network
+	}
+	if timeout != nil && *timeout != 0 {
+		tmo = *timeout
+	}
+
 	request, err := json.Marshal(struct {
 		Kind        string             `json:"kind"`
 		Interactive bool               `json:"interactive"`
 		Profiles    []ProfileSelection `json:"profiles"`
 		Password    string             `json:"password,omitempty"`
+		Defaults    Defaults           `json:"defaults"`
 	}{
 		Kind:        "file",
 		Interactive: interactive,
 		Profiles:    profiles,
 		Password:    pw,
+		Defaults: Defaults{
+			Timeout: tmo,
+			Network: net,
+		},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Porting Python client's `submit_sample_file` based on #27 for the ability to specify timeout and network options in Golang
